### PR TITLE
Fix color group examples

### DIFF
--- a/technical-reports/color/color-terminology.md
+++ b/technical-reports/color/color-terminology.md
@@ -2,38 +2,38 @@
 
 This section provides a high-level overview of the terminology used in the specification and how it relates to [color science](https://en.wikipedia.org/wiki/Color_science) and [colorimetry](https://en.wikipedia.org/wiki/Colorimetry).
 
-<dfn>Color space<dfn>
+<dfn>Color space</dfn>
 
 A color space is a specific organization of colors, which helps in the reproduction of color in both physical and digital realms. It defines a range of colors that can be represented and manipulated.
 
-<dfn>Color model<dfn>
+<dfn>Color model</dfn>
 
 A color model is a mathematical representation of colors within a specific [=color space=]. It defines how colors are represented as numerical values, typically using components.
 
-<dfn data-lt="gamut">Color gamut<dfn>
+<dfn data-lt="gamut">Color gamut</dfn>
 
 A color gamut is the complete range of colors that can be represented in a specific color space. It defines the limits of color reproduction for that space.
 
-<dfn data-lt="components">Component<dfn>
+<dfn data-lt="components">Component</dfn>
 
 A component is a single value that defines a part of a color in a specific color space. For example, in the RGB color space, the components are red, green, and blue.
 
-<dfn>Hue<dfn>
+<dfn>Hue</dfn>
 
 Hue is the attribute of a color that allows it to be classified as red, green, blue, etc. In many color spaces, hue is represented as an angle on a color wheel. Different color spaces may position colors differently on the wheel.
 
-<dfn>Saturation<dfn>
+<dfn>Saturation</dfn>
 
 Saturation is the colorfulness of a color relative to its own brightness. It describes how much gray is present in a color. A fully saturated color has no gray, while a desaturated color appears more grayish. It is inherently tied to both [=chroma=] and [=lightness=], especially in models like HSL or HSV. A color can be highly saturated but still appear light or dark depending on its lightness.
 
-<dfn>Lightness<dfn>
+<dfn>Lightness</dfn>
 
 Lightness is the perceived brightness of a color. It describes how light or dark a color appears.
 
-<dfn>Chroma<dfn>
+<dfn>Chroma</dfn>
 
 Chroma refers to the colorfulness of a color relative to the brightness of a similarly illuminated white. It measures how pure or intense a color appears. In the CIE LCH color model (Lightness, Chroma, Hue), Chroma is independent of lightness and expresses how far a color is from neutral gray along the chromatic axis.
 
-<dfn>Alpha<dfn>
+<dfn>Alpha</dfn>
 
 Alpha is a component that represents the transparency of a color. It defines how opaque or transparent a color is, with the minimum value (usually 0) being fully transparent and the maximum value (usually 1) being fully opaque.

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -84,7 +84,7 @@ Group keys without a dollar sign (`$`) prefix denote:
       "Token name": {
         "$value": {
           "colorSpace": "srgb",
-          "channels": [0, 0, 0]
+          "components": [0, 0, 0]
         }
       }
     }
@@ -102,14 +102,14 @@ Group keys without a dollar sign (`$`) prefix denote:
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "channels": [0.667, 0.733, 0.8]
+            "components": [0.667, 0.733, 0.8]
           }
         },
         "Token 2 name": {
           "$type": "color",
           "$value": {
             "colorSpace": "srgb",
-            "channels": [0.867, 0.933, 1]
+            "components": [0.867, 0.933, 1]
           }
         }
       }


### PR DESCRIPTION
## Summary
- update color token properties in group examples to use `components`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: code style issues)*
- `npm run validate` *(fails: respec not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa425593c832f82d23d0130d476ae