### PR TITLE
Fix composite token example mismatch

### DIFF
--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -121,7 +121,15 @@ Here's [an example of a composite shadow token](https://design-tokens.github.io/
   "shadow-token": {
     "$type": "shadow",
     "$value": {
-      "color": "#00000080",
+      "color": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "alpha": 0.5,
+          "hex": "#000000"
+        }
+      },
       "offsetX": { "value": 0.5, "unit": "rem" },
       "offsetY": { "value": 0.5, "unit": "rem" },
       "blur": { "value": 1.5, "unit": "rem" },


### PR DESCRIPTION
## Summary
- update composite token example in `terminology.md` to match the one linked from the spec

## Testing
- `npm run lint` *(fails: Code style issues found)*
- `npm run validate:index` *(fails: `respec` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c258e274832fb36bfd6b6ca77859